### PR TITLE
Add setup and teardown for EC2 instances and security groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Desktop.ini
 # Temporary files
 tmp/
 temp/
+
+config.env

--- a/public-user-data.sh
+++ b/public-user-data.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+yum update -y
+yum install httpd -y
+service httpd start
+chkconfig httpd on
+IP_ADDR=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` \
+&& curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/public-ipv4)
+echo "ASG instance with IP $IP_ADDR" > /var/www/html/index.html

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,15 @@
 
 source ./variables.sh
 
+
+if [ -f "config.env" ]; then
+    source config.env
+    echo "Here is your ip address: ${MY_IP}"
+else
+    echo "Missing config.env file. Please create it with your public IP."
+    exit 1
+fi
+
 # Function to get resource ID by tag name
 get_resource_id() {
     local resource_type=$1
@@ -29,3 +38,10 @@ echo "Found Internet Gateway: ${IGW_ID}"
 
 PUBLIC_RT_ID=$(get_resource_id route-table $PUBLIC_RT_NAME "RouteTables[0].RouteTableId")
 echo "Found Public Route Table: ${PUBLIC_RT_ID}"
+
+echo "Terminating EC2 instances..."
+INSTANCE_IDS=$(aws ec2 describe-instances \
+    --filters "Name=vpc-id,Values=${VPC_ID}" "Name=instance-state-name,Values=running,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text)
+echo "EC2 ids: ${INSTANCE_IDS}"

--- a/variables.sh
+++ b/variables.sh
@@ -7,8 +7,15 @@ export AWS_REGION="us-east-1"
 export VPC_NAME="gl-vpc"
 export IGW_NAME="gl-igw"
 export PUBLIC_RT_NAME="PublicRT"
+export PUBLIC_SG_NAME="PublicSG"
+export PRIVATE_SG_NAME="PrivateSG"
 
 # cidr blocks
 export VPC_CIDR="10.0.0.0/16"
 export PUBLIC_SUBNET_CIDR="10.0.1.0/24"
 export PRIVATE_SUBNET_CIDR="10.0.2.0/24"
+
+# ec2 configuration
+export AMI_ID="ami-0984f4b9e98be44bf"
+export INSTANCE_TYPE="t2.micro"
+export KEY_PAIR_NAME="liftshift"


### PR DESCRIPTION
Configured `tear-down.sh` to terminate EC2 instances and delete security groups. Updated `variables.sh` with EC2 configuration variables. Modified `set-up.sh` to create and configure security groups, and launch EC2 instances. Added `public-user-data.sh` for instance initialization. Updated `.gitignore` to exclude `config.env`.