### PR TITLE
Add private security group and EC2 instance management

### DIFF
--- a/tear-down.sh
+++ b/tear-down.sh
@@ -39,6 +39,12 @@ PUBLIC_SG_ID=$(aws ec2 describe-security-groups \
     --output text)
 echo "Found Public Security Group: ${PUBLIC_SG_ID}"
 
+PRIVATE_SG_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=${PRIVATE_SG_NAME}" \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text)
+echo "Found Private Security Group: ${PRIVATE_SG_ID}"
+
 # removing resources
 
 # Terminate EC2 instances
@@ -50,9 +56,9 @@ INSTANCE_IDS=$(aws ec2 describe-instances \
 
 if [ -n "$INSTANCE_IDS" ]; then
     echo "Terminating EC2 instances: ${INSTANCE_IDS}"
-    aws ec2 terminate-instances --instance-ids "${INSTANCE_IDS}"
+    aws ec2 terminate-instances --instance-ids $(echo $INSTANCE_IDS)
     echo "Waiting for instances to terminate..."
-    aws ec2 wait instance-terminated --instance-ids" ${INSTANCE_IDS}"
+    aws ec2 wait instance-terminated --instance-ids $(echo $INSTANCE_IDS)
     echo "EC2 instances terminated: ${INSTANCE_IDS}"
 fi
 
@@ -62,6 +68,12 @@ if [ -n "$PUBLIC_SG_ID" ] && [ "$PUBLIC_SG_ID" != "None" ]; then
     echo "Deleting Public Security Group: ${PUBLIC_SG_ID}"
     aws ec2 delete-security-group --group-id "${PUBLIC_SG_ID}"
     echo "Public Security Group deleted: ${PUBLIC_SG_ID}"
+fi
+
+if [ -n "$PRIVATE_SG_ID" ] && [ "$PRIVATE_SG_ID" != "None" ]; then
+    echo "Deleting Private Security Group: ${PRIVATE_SG_ID}"
+    aws ec2 delete-security-group --group-id "${PRIVATE_SG_ID}"
+    echo "Private Security Group deleted: ${PRIVATE_SG_ID}"
 fi
 
 # delete route table association and routes

--- a/variables.sh
+++ b/variables.sh
@@ -9,6 +9,8 @@ export IGW_NAME="gl-igw"
 export PUBLIC_RT_NAME="PublicRT"
 export PUBLIC_SG_NAME="PublicSG"
 export PRIVATE_SG_NAME="PrivateSG"
+export PUBLIC_EC2_INSTANCE_NAME="PublicInstance"
+export PRIVATE_EC2_INSTANCE_NAME="PrivateInstance"
 
 # cidr blocks
 export VPC_CIDR="10.0.0.0/16"


### PR DESCRIPTION
Added functionality for handling a private security group and launching a private EC2 instance in the setup script. Updated tear-down script to include steps for deleting the private security group. Introduced new variables for instance names to the variables script.